### PR TITLE
regression: downgrade dynaconf to 3.1.11 (#47)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flask-restx==1.1.0
 requests==2.28.2
 waitress==2.1.2
 st4sd-runtime-core
-dynaconf==3.1.12
+dynaconf~=3.1.11


### PR DESCRIPTION
## Context

Downgrades Dynaconf to 3.1.11 due to Python version requirements

## Change list

- Downgrades Dynaconf to v3.1.11

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
