### PR TITLE
build: use python:3.10-alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM mirror.gcr.io/python:3.10-alpine
+FROM mirror.gcr.io/python:3.10-alpine AS build_stage
 RUN apk update && \
-    apk add gcc linux-headers musl-dev && \
-    apk cache clean && apk cache purge
+    apk add gcc linux-headers musl-dev
+COPY requirements.txt .
+RUN pip install --upgrade pip setuptools && pip install -r requirements.txt
 
+
+FROM mirror.gcr.io/python:3.10-alpine
+COPY --from=build_stage /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY requirements.txt .
 COPY *.py ./
 COPY apis ./apis
 COPY utils ./utils
 COPY settings.toml ./settings.toml
-RUN pip install -r requirements.txt
 EXPOSE 8085
 
 ENTRYPOINT ["python", "app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM mirror.gcr.io/python:3.10-alpine AS build_stage
 RUN apk update && \
     apk add gcc linux-headers musl-dev
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --upgrade pip setuptools && pip install -r requirements.txt
 
 FROM mirror.gcr.io/python:3.10-alpine
-RUN pip install --upgrade pip setuptools
 COPY --from=build_stage /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+RUN pip install --upgrade pip setuptools
 COPY requirements.txt .
 COPY *.py ./
 COPY apis ./apis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM quay.io/st4sd/official-base/st4sd-runtime-core:py310-latest
+FROM mirror.gcr.io/python:3.10-alpine
+RUN apk update && \
+    apk add gcc linux-headers musl-dev && \
+    apk cache clean && apk cache purge
+
 COPY requirements.txt .
 COPY *.py ./
 COPY apis ./apis

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM mirror.gcr.io/python:3.10-alpine AS build_stage
 RUN apk update && \
     apk add gcc linux-headers musl-dev
 COPY requirements.txt .
-RUN pip install --upgrade pip setuptools && pip install -r requirements.txt
-
+RUN pip install -r requirements.txt
 
 FROM mirror.gcr.io/python:3.10-alpine
+RUN pip install --upgrade pip setuptools
 COPY --from=build_stage /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 COPY requirements.txt .
 COPY *.py ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==3.1.1
-flask-cors==6.0.0
+flask-cors==6.0.1
 flask-restx==1.3.0
-requests==2.32.3
+requests==2.32.4
 waitress==3.0.2
 st4sd-runtime-core
 dynaconf==3.2.11


### PR DESCRIPTION
## Context

CVEs are present in the runtime-core base image and updates are available for the dependencies

## Change list

- Changes the base image to `python:3.10-alpine`
- Updates `flask-cors` to 6.0.1
- Updates `requests` to 2.32.4


## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
